### PR TITLE
TRACEFOSS-1110: removed bug with infinit loading animation on parts tree

### DIFF
--- a/src/app/mocks/services/parts-mock/parts.handler.ts
+++ b/src/app/mocks/services/parts-mock/parts.handler.ts
@@ -42,9 +42,11 @@ export const partsHandlers = [
     return res(ctx.status(200), ctx.json(applyPagination(mockBmwAssets, pagination)));
   }),
 
-  rest.post(`*${environment.apiUrl}/assets/detail-information`, (req, res, ctx) => {
-    const { assetIds } = typeof req.body === 'string' ? JSON.parse(req.body) : req.body;
-    return res(ctx.status(200), ctx.json(assetIds.map(id => getAssetById(id))));
+  rest.post(`*${environment.apiUrl}/assets/detail-information`, async (req, res, ctx) => {
+    const { assetIds } = await req.json();
+
+    const response = assetIds.map(id => getAssetById(id));
+    return res(ctx.status(200), ctx.json(response.filter(data => !!data)));
   }),
 
   rest.get(`*${environment.apiUrl}/assets/:partId`, (req, res, ctx) => {
@@ -56,7 +58,7 @@ export const partsHandlers = [
   rest.patch(`*${environment.apiUrl}/assets/:partId`, (req, res, ctx) => {
     const { partId } = req.params;
     const currentPart = getAssetById(partId as string);
-    return res(ctx.status(200), ctx.json({ ...currentPart, ...(req.body as Record<string, any>) }));
+    return res(ctx.status(200), ctx.json({ ...currentPart, ...req.json() }));
   }),
 
   rest.get(`*${environment.apiUrl}/assets/:assetId/children/:childId`, (req, res, ctx) => {
@@ -81,7 +83,9 @@ export const partsHandlersTest = [
 
   rest.post(`*${environment.apiUrl}/assets/detail-information`, async (req, res, ctx) => {
     const { assetIds } = await req.json();
-    return res(ctx.status(200), ctx.json(assetIds.map(id => mockAssetList[id] || getAssetById(id))));
+
+    const response = assetIds.map(id => mockAssetList[id] || getAssetById(id));
+    return res(ctx.status(200), ctx.json(response.filter(data => !!data)));
   }),
 
   rest.get(`*${environment.apiUrl}/assets/:partId`, (req, res, ctx) => {
@@ -93,7 +97,7 @@ export const partsHandlersTest = [
   rest.patch(`*${environment.apiUrl}/assets/:partId`, (req, res, ctx) => {
     const { partId } = req.params;
     const currentPart = mockAssetList[partId as string];
-    return res(ctx.status(200), ctx.json({ ...currentPart, ...(req.body as Record<string, any>) }));
+    return res(ctx.status(200), ctx.json({ ...currentPart, ...req.json() }));
   }),
 
   rest.get(`*${environment.apiUrl}/assets/:assetId/children/:childId`, (req, res, ctx) => {

--- a/src/app/modules/shared/modules/relations/core/relations.facade.ts
+++ b/src/app/modules/shared/modules/relations/core/relations.facade.ts
@@ -169,13 +169,14 @@ export class RelationsFacade {
       bufferTime(500),
       filter(childList => !!childList.length),
       switchMap(childList => {
-        children = childList;
-        return this.partsService.getPartDetailOfIds(children.reduce((p, c) => [...p, ...c], []));
+        children = childList.reduce((p, c) => [...p, ...c], []);
+        return this.partsService.getPartDetailOfIds(children);
       }),
       catchError(_ => of(children.map(id => ({ id, children: [] } as Part)))),
       map(childrenData =>
-        childrenData.map((child, index) => RelationsAssembler.assemblePartForRelation(child, children[index])),
+        children.map(id => childrenData.find(data => data.id === id) || ({ id, children: [] } as Part)),
       ),
+      map(childrenData => childrenData.map(child => RelationsAssembler.assemblePartForRelation(child))),
       tap(childrenData => this.addLoadedElements(childrenData)),
       tap(childrenData => this.requestPartDetailsStream.next(childrenData)),
     );


### PR DESCRIPTION
Because we changed how parts are loaded (with a queue), the fallback check was broken.
What happens when a part does not exist in the BE?

Here i do a check after we receive the list of IDs and add blank items for IDs that where not returned.